### PR TITLE
[firefox-settings] Turn off Google trends

### DIFF
--- a/firefox-settings/PKGBUILD
+++ b/firefox-settings/PKGBUILD
@@ -1,13 +1,13 @@
 # Maintainer: Vasiliy Stelmachenok <ventureo@yandex.ru>
 pkgname=firefox-settings
-pkgver=20250422
-pkgrel=2
+pkgver=20250509
+pkgrel=1
 pkgdesc='My settings for Firefox browser'
 depends=('firefox')
 arch=('any')
 url="https://github.com/ventureoo/PKGBUILDs"
 source=(pure.js)
-sha256sums=('ca1a56a647659196c3a5d8c84f00d597c295f4091398d6145e7a9942a6497dd3')
+sha256sums=('909d33079d612d8862e6d89022859e981701e7b52af87be1b71061f2a8940539')
 
 pkgver() {
     date +%Y%m%d

--- a/firefox-settings/pure.js
+++ b/firefox-settings/pure.js
@@ -46,6 +46,7 @@ pref("browser.newtabpage.activity-stream.unifiedAds.spocs.enabled",	false, locke
 pref("browser.newtabpage.activity-stream.unifiedAds.tiles.enabled", false, locked);
 pref("browser.places.interactions.enabled", false, locked);
 pref("browser.tabs.crashReporting.sendReport", false, locked);
+pref("browser.urlbar.suggest.trending", false, locked);
 pref("captivedetect.canonicalURL", "", locked);
 pref("devtools.debugger.remote-enabled", false, locked);
 pref("dom.private-attribution.submission.enabled", false, locked);


### PR DESCRIPTION
Who cares Google

Ref: https://support.mozilla.org/en-US/kb/use-google-trending-search-firefox-address-bar