### PR TITLE
Improvements to firefox-pure

### DIFF
--- a/firefox-pure/.SRCINFO
+++ b/firefox-pure/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = firefox-pure
 	pkgdesc = Fast, Private & Safe Web Browser
 	pkgver = 142.0.1
-	pkgrel = 1
+	pkgrel = 2
 	url = https://www.mozilla.org/firefox/
 	arch = x86_64
 	license = MPL-2.0
@@ -45,7 +45,6 @@ pkgbase = firefox-pure
 	depends = libpulse
 	depends = libvpx
 	depends = libwebp
-	depends = libxss
 	depends = mime-types
 	depends = nspr
 	depends = nss

--- a/firefox-pure/PKGBUILD
+++ b/firefox-pure/PKGBUILD
@@ -6,7 +6,7 @@
 
 pkgname=firefox-pure
 pkgver=142.0.1
-pkgrel=1
+pkgrel=2
 pkgdesc="Fast, Private & Safe Web Browser"
 url="https://www.mozilla.org/firefox/"
 arch=(x86_64)


### PR DESCRIPTION
Improvements overall with be
- independent from X libraries, (libxss)
- disable debug
- enable strip
- use system libraries like "png" and "pipewire".